### PR TITLE
Update extension based on file uploaded

### DIFF
--- a/hqmedia.upload_controller.js
+++ b/hqmedia.upload_controller.js
@@ -286,6 +286,10 @@ function BaseHQMediaUploadController (uploader_name, marker, options) {
         if (!self.allowCloseDuringUpload) {
             self.allowClose = false;
         }
+        if (!self.isMultiFileUpload) {
+            var newExtension = '.' + self.filesInQueueUI[0].get('name').split('.').pop().toLowerCase();
+            self.uploadParams.path = self.uploadParams.path.replace(/\.[^/.]+$/, newExtension);
+        }
         $(self.uploadButtonSelector).addClass('disabled').removeClass('btn-success');
         self.startUploadUI();
         var postParams = _.clone(self.uploadParams);


### PR DESCRIPTION
Related to: https://github.com/dimagi/Vellum/pull/292

http://manage.dimagi.com/default.asp?151390#844016

Might not be the best place to put this code. (First foray into MediaUploader). From my testing it will still check the supported file types that were passed in during initialization, so it shouldn't be a worry.

Reason I did this:
Vellum passes in the path it wants the multimedia saved to, and this returns a path once it has been saved. If the path is not of the correct extension the user has to know to go into advanced path, change the extension, then try to upload again. Here once the file is uploaded the extension is changed, and the final filepath is returned to Vellum