### PR TITLE
escape newlines

### DIFF
--- a/hqmedia.upload_controller.js
+++ b/hqmedia.upload_controller.js
@@ -554,7 +554,7 @@ function HQMediaFileUploadController (uploader_name, marker, options) {
         $(curUpload.cancel).addClass('hide');
         $(curUpload.progressBarContainer).removeClass('active').addClass('progress-success');
 
-        var response = $.parseJSON(event.data);
+        var response = $.parseJSON(event.data.replace(/\r|\n|\r\n/, '\\n'));
         $('[data-hqmediapath="' + self.currentReference.path + '"]').trigger('mediaUploadComplete', response);
         if (!response.errors.length) {
             self.updateUploadFormUI();


### PR DESCRIPTION
Escape a newline before parsing json.

Should also be fixed on the server, but I couldn't because using `json.dumps(data)` makes the flash widget crash. (doesn't happen in the html5 uploader, but https://github.com/dimagi/MediaUploader/blob/master/hqmedia.upload_controller.js#L184-L185)

cc: @czue 