### PR TITLE
Don't show existing file template when media has been deleted

### DIFF
--- a/hqmedia.upload_controller.js
+++ b/hqmedia.upload_controller.js
@@ -528,7 +528,7 @@ function HQMediaFileUploadController (uploader_name, marker, options) {
         var $existingFile = $(self.existingFileSelector);
         $(self.fileUploadCompleteSelector).addClass('hide');
 
-        if (self.currentReference.isMediaMatched()) {
+        if (self.currentReference.getUrl()) {
             $existingFile.removeClass('hide');
             $existingFile.find('.hqm-existing-controls').html(self.processExistingFileTemplate(self.currentReference.getUrl()));
         } else {


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?252941

`isMediaMatched` depends on `is_matched` which presumably doesn't get cleared when media is deleted (at least, there's no code that sets it to `false`). That might indicate a larger problem - I remember having trouble with the "matching" logic when working on printing from case detail - but I'm inclined make my changes to this repo as small as possible lest the whole house of cards come crashing down. Did basic sanity testing (upload, replace, and delete).

@biyeun / @dannyroberts 