### PR TITLE
Media preview displaying even after removal

### DIFF
--- a/hqmedia.upload_controller.js
+++ b/hqmedia.upload_controller.js
@@ -528,7 +528,7 @@ function HQMediaFileUploadController (uploader_name, marker, options) {
         var $existingFile = $(self.existingFileSelector);
         $(self.fileUploadCompleteSelector).addClass('hide');
 
-        if (self.currentReference.getUrl()) {
+        if (self.currentReference.getUrl() && self.currentReference.isMediaMatched()) {
             $existingFile.removeClass('hide');
             $existingFile.find('.hqm-existing-controls').html(self.processExistingFileTemplate(self.currentReference.getUrl()));
         } else {


### PR DESCRIPTION
Caused by https://github.com/dimagi/MediaUploader/pull/22

MediaUploader is due for a refactor, but I'm going to keep applying band-aids for now.

Did basic sanity testing (and testing for the issue https://github.com/dimagi/MediaUploader/pull/22 was fixing).

@nickpell / @dannyroberts 